### PR TITLE
[SHC-330] Adding ability to set first and last splits, so that non-al…

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -158,8 +158,8 @@ case class HBaseRelation(
         maxVersions.foreach(v => cf.setMaxVersions(v))
         tableDesc.addFamily(cf)
       }
-      val startKey = catalog.shcTableCoder.toBytes("aaaaaaa")
-      val endKey = catalog.shcTableCoder.toBytes("zzzzzzz")
+      val startKey = catalog.shcTableCoder.toBytes(catalog.splitRange._1)
+      val endKey = catalog.shcTableCoder.toBytes(catalog.splitRange._2)
       val splitKeys = Bytes.split(startKey, endKey, catalog.numReg - 3)
       admin.createTable(tableDesc, splitKeys)
       val r = connection.getRegionLocator(tName).getAllRegionLocations

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseTableCatalog.scala
@@ -167,7 +167,8 @@ case class HBaseTableCatalog(
     sMap: SchemaMap,
     tCoder: String,
     coderSet: Set[String],
-    val numReg: Int) extends Logging {
+    val numReg: Int,
+    val splitRange: (String, String)) extends Logging {
   def toDataType = StructType(sMap.toFields)
   def getField(name: String) = sMap.getField(name)
   def getRowKey: Seq[Field] = row.fields
@@ -250,6 +251,8 @@ object HBaseTableCatalog {
   val tableCoder = "tableCoder"
   // The version number of catalog
   val cVersion = "version"
+  val minTableSplitPoint = "minTableSplitPoint"
+  val maxTableSplitPoint = "maxTableSplitPoint"
   /**
    * User provide table schema definition
    * {"tablename":"name", "rowkey":"key1:key2",
@@ -295,7 +298,10 @@ object HBaseTableCatalog {
     val numReg = parameters.get(newTable).map(x => x.toInt).getOrElse(0)
     val rKey = RowKey(map.get(rowKey).get.asInstanceOf[String])
 
-    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg)
+    val minSplit = parameters.get(minTableSplitPoint).getOrElse("aaaaaa")
+    val maxSplit = parameters.get(maxTableSplitPoint).getOrElse("zzzzzz")
+
+    HBaseTableCatalog(nSpace, tName, rKey, SchemaMap(schemaMap), tCoder, coderSet, numReg, (minSplit, maxSplit))
   }
 
   /**


### PR DESCRIPTION
…phabetic splits can be easily supported

## What changes were proposed in this pull request?

Adds two properties that allow the first and last split to be set by the user. This allows the use of more complex split preferences, as well as enables scenarios such as numeric-only keys, which were underserved in earlier versions.

## How was this patch tested?

Two unit tests were added. One tests that for alphabetic keys, the rows are dispersed between regions correctly. The other uses numeric keys and sets the first and last splits accordingly. This also checks that the rows have been dispersed appropriately across regions.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
